### PR TITLE
Datepicker fix for MPOnly flow

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -235,6 +235,17 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 $ELEMENT.addClass( CLASSES.active )
                 aria( ELEMENT, 'expanded', true )
 
+                // If the picker is within an iframe, set the picker height
+                function calculateTop() {
+										return (window.parent.document.documentElement.scrollTop || window.parent.document.body.scrollTop || window.parent.pageYOffset || 0) + "px";
+
+                }
+
+                if (window.self != window.top) {
+                    document.getElementsByClassName('picker__frame')[0].style.top=calculateTop();
+                    document.getElementsByClassName('picker__frame')[0].style.position="fixed";
+                }
+
                 // * A Firefox bug, when `html` has `overflow:hidden`, results in
                 //   killing transitions :(. So add the “opened” state on the next tick.
                 //   Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=625289


### PR DESCRIPTION
Partial Fix for issue #8491

Fixes Datepicker scrolling in MPOnly Flow

http://recordit.co/o8cvSExpbB

### Test Plan

1. Walk through MPCentric registration.
2. Click the calendar, the modal will appear in the viewport

@joshdover @rblakemesser 